### PR TITLE
Assign copyright to Evie

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Cariad Eccleston
+Copyright (c) 2022 Evie Finch
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,9 @@ MIT License
 
 Copyright (c) 2022 Evie Finch
 
+Phrase generation is based on https://github.com/cariad/wa11y.co released under
+the MIT license and copyright (c) 2022 Cariad Eccleston.
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
Update the license text to:

1. Assign copyright to @qt-dork
2. Acknowledge that the phrase generation code was released under the MIT license at [github.com/cariad/wa11y.co](https://github.com/cariad/wa11y.co)